### PR TITLE
Add gruvbox-dark-theme 

### DIFF
--- a/airline-gruvbox-dark-theme.el
+++ b/airline-gruvbox-dark-theme.el
@@ -1,5 +1,3 @@
-;;; airline-dark --- Summary
-;;; Commentary: Medium version of gruvbox dark
 ;;; Code:
 
 (deftheme airline-gruvbox-dark

--- a/airline-gruvbox-dark.el
+++ b/airline-gruvbox-dark.el
@@ -1,0 +1,46 @@
+;;; airline-dark --- Summary
+;;; Commentary: Medium version of gruvbox dark
+;;; Code:
+
+(deftheme airline-gruvbox-dark
+  "source: https://github.com/morhetz/gruvbox/blob/master/autoload/airline/themes/gruvbox.vim")
+
+(let ((normal-outer-foreground  "#282828") (normal-outer-background  "#a89984")
+      (normal-inner-foreground  "#ebdbb2") (normal-inner-background  "#3c3836")
+      (normal-center-foreground "#ebdbb2") (normal-center-background "#665c54")
+
+      (insert-outer-foreground  "#282828") (insert-outer-background  "#83a598")
+      (insert-inner-foreground  "#ebdbb2") (insert-inner-background  "#3c3836")
+      (insert-center-foreground "#ebdbb2") (insert-center-background "#665c54")
+
+      (visual-outer-foreground  "#282828") (visual-outer-background  "#fd971f")
+      (visual-inner-foreground  "#ebdbb2") (visual-inner-background  "#3c3836")
+      (visual-center-foreground "#282828") (visual-center-background "#bdae93")
+
+      (replace-outer-foreground  "#282828") (replace-outer-background  "#8ec07c")
+      (replace-inner-foreground  "#ebdbb2") (replace-inner-background  "#3c3836")
+      (replace-center-foreground "#ebdbb2") (replace-center-background "#665c54")
+
+      (emacs-outer-foreground  "#282828") (emacs-outer-background  "#5f00af")
+      (emacs-inner-foreground  "#ebdbb2") (emacs-inner-background  "#3c3836")
+      (emacs-center-foreground "#ebdbb2") (emacs-center-background "#665c54")
+
+      (inactive1-foreground "#1d2021") (inactive1-background "#282828")
+      (inactive2-foreground "#282828") (inactive2-background "#3c3836")
+      (inactive3-foreground "#282828") (inactive3-background "#665c54"))
+
+  (airline-themes-set-deftheme 'airline-gruvbox-dark)
+
+  (when airline-cursor-colors
+    (progn
+     (setq evil-emacs-state-cursor   emacs-outer-background)
+     (setq evil-normal-state-cursor  normal-outer-background)
+     (setq evil-insert-state-cursor  `(bar ,insert-outer-background))
+     (setq evil-replace-state-cursor replace-outer-background)
+     (setq evil-visual-state-cursor  visual-outer-background)))
+  )
+
+(airline-themes-set-modeline)
+
+(provide-theme 'airline-gruvbox-dark)
+;;; airline-gruvbox-dark-theme.el ends here


### PR DESCRIPTION
This is a port of https://github.com/morhetz/gruvbox

Looks (almost) exactly like the original : 
![normal](https://user-images.githubusercontent.com/25652765/38594046-886c7cc8-3d12-11e8-83d3-05027ef2841a.png)
![insert](https://user-images.githubusercontent.com/25652765/38594050-8f27fd3a-3d12-11e8-9dd8-6b42d91372c2.png)
![replace](https://user-images.githubusercontent.com/25652765/38594053-90d96e70-3d12-11e8-9e9c-8c953eb2a1fb.png)
![visual](https://user-images.githubusercontent.com/25652765/38594055-92257d6e-3d12-11e8-86ad-cb59469ef9bd.png)
Here is the original : 
![original](https://camo.githubusercontent.com/e80523c76e0b2588c56e4370ccde08fb8affbd38/687474703a2f2f692e696d6775722e636f6d2f775251636555522e706e67)